### PR TITLE
refactor: update packages and LXD snap channel

### DIFF
--- a/10_install_start.sh
+++ b/10_install_start.sh
@@ -103,12 +103,7 @@ source config/03_OTHER_VARS
 #############
 echo "$($_ORANGE_)Update and Upgrade system packages and default apt configuration$($_WHITE_)"
 
-PACKAGES="vim apt-utils bsd-mailx unattended-upgrades apt-listchanges bind9-host logrotate postfix"
-
-if [ "$DEBIAN_RELEASE" == "stretch" ] ; then
-    # Add backports
-    echo 'deb http://ftp.fr.debian.org/debian stretch-backports main' > /etc/apt/sources.list.d/stretch-backports.list
-fi
+PACKAGES="vim apt-utils bsd-mailx unattended-upgrades apt-listchanges bind9-host logrotate postfix python3.12 python-is-python3"
 
 
 apt-get update > /dev/null
@@ -189,12 +184,12 @@ EOF
 iptables-restore /etc/iptables/rules.v4
 
 ##### DEBIAN
-echo "$($_ORANGE_)Install: snapd, udev, btrfs and lvm$($_WHITE_)"
-DEBIAN_FRONTEND=noninteractive apt-get -y install snapd udev btrfs-tools lvm2 thin-provisioning-tools > /dev/null
+echo "$($_ORANGE_)Install: snapd, udev and btrfs$($_WHITE_)"
+DEBIAN_FRONTEND=noninteractive apt-get -y install snapd udev btrfs-progs > /dev/null
 DEBIAN_FRONTEND=noninteractive apt-get clean
 
 echo "$($_ORANGE_)Install: LXD with snap$($_WHITE_)"
-snap install lxd --channel="$LXD_VERSION"
+snap install lxd --channel="$LXD_SNAP_CHANNEL"
 
 ##### UBUNTU
 ## Install LXD package

--- a/11_install_next.sh
+++ b/11_install_next.sh
@@ -208,11 +208,7 @@ sleep 5
 
 echo "$($_ORANGE_)Container TEMPLATE: Update, upgrade and install common packages$($_WHITE_)"
 
-PACKAGES="git vim apt-utils bsd-mailx postfix"
-
-if [ "$DEBIAN_RELEASE" == "stretch" ] ; then
-    lxc exec z-template -- bash -c "echo 'deb http://ftp.fr.debian.org/debian stretch-backports main' > /etc/apt/sources.list.d/stretch-backports.list"
-fi
+PACKAGES="git vim apt-utils bsd-mailx postfix python3.12 python-is-python3"
 
 lxc exec z-template -- bash -c "
     apt-get update > /dev/null

--- a/config/03_OTHER_VARS
+++ b/config/03_OTHER_VARS
@@ -99,8 +99,6 @@ LXD_DEFAULT_STORAGE="$LXD_STORAGE_LOOP_BTRFS"
 
 ################################################################################
 
-# LXD Version (with snap)
-# see https://linuxcontainers.org/lxd/news/
-# 2.0 (11/04/2016) with a 5 years support commitment from upstream, ending on 1st of June 2021
-# 3.0 (02/04/2018) will be supported until June 2023
-LXD_VERSION="3.0"
+# LXD snap channel
+# see https://snapcraft.io/lxd for available channels
+LXD_SNAP_CHANNEL="latest/stable"

--- a/containers/22_configure_rvprx.sh
+++ b/containers/22_configure_rvprx.sh
@@ -72,12 +72,7 @@ echo "$($_ORANGE_)Install specific packages$($_WHITE_)"
 lxc exec rvprx -- bash -c "DEBIAN_FRONTEND=noninteractive apt-get -y install nginx iptables > /dev/null"
 
 # Certbot for Nginx
-if [ "$DEBIAN_RELEASE" == "stretch" ] ; then
-    # If stretch release, install with backports (not available in std repo)
-    lxc exec rvprx -- bash -c "DEBIAN_FRONTEND=noninteractive apt-get -y install python3-certbot-nginx/stretch-backports > /dev/null"
-else
-    lxc exec rvprx -- bash -c "DEBIAN_FRONTEND=noninteractive apt-get -y install python3-certbot-nginx > /dev/null"
-fi
+lxc exec rvprx -- bash -c "DEBIAN_FRONTEND=noninteractive apt-get -y install python3-certbot-nginx > /dev/null"
 
 
 # conf file letsencrypt


### PR DESCRIPTION
## Summary
- remove Debian stretch backports handling
- replace deprecated btrfs-tools with btrfs-progs and drop unused packages
- add Python 3.12 and python-is-python3 to default installs
- install LXD from configurable modern snap channel

## Testing
- `bash -n 10_install_start.sh 11_install_next.sh containers/22_configure_rvprx.sh config/03_OTHER_VARS`
- `shellcheck 10_install_start.sh 11_install_next.sh containers/22_configure_rvprx.sh config/03_OTHER_VARS` *(warnings: SC2188, SC2129, SC2086, SC2005, SC2154, SC1091, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68af15af162c8329a0f02408560ab769