### PR TITLE
Update to PHP 8.2 and Apache remoteip

### DIFF
--- a/config/03_OTHER_VARS
+++ b/config/03_OTHER_VARS
@@ -2,7 +2,7 @@
 #### This file contain other tunable vars 
 ################################################################################
 
-NEXTCLOUD_URL="https://download.nextcloud.com/server/releases/nextcloud-13.0.5.tar.bz2"
+NEXTCLOUD_URL="https://download.nextcloud.com/server/releases/latest.tar.bz2"
 
 # Default MAX upload file size
 # The default value is 512M
@@ -44,7 +44,7 @@ CREATE_CERTIFICATES=true
 # LXD default storage type (driver) and size
 #
 # For test time, the following command is used:
-# time apt -y install apache2 php7.0
+# time apt -y install apache2 php8.2
 #
 ## LVM in loop device
 # Time: 1m31.501s


### PR DESCRIPTION
## Summary
- use PHP 8.2 packages and FPM for the Nextcloud container
- replace deprecated rpaf module with Apache's built-in remoteip
- download latest Nextcloud release via `NEXTCLOUD_URL`

## Testing
- `bash -n containers/24_configure_cloud.sh`
- `bash -n config/03_OTHER_VARS`


------
https://chatgpt.com/codex/tasks/task_e_68af15b40d708329998cd721599f83c7