### PR TITLE
Update Collabora repo configuration for Debian 12

### DIFF
--- a/containers/25_configure_collabora.sh
+++ b/containers/25_configure_collabora.sh
@@ -76,10 +76,10 @@ DOMAIN=$(echo $FQDN| sed 's#\.#\\\\.#g')
 lxc exec collabora -- bash -c "
                                # Update and install basic packages
                                apt-get update > /dev/null
-                               apt-get -y install gnupg apt-transport-https > /dev/null
+                               apt-get -y install curl gnupg > /dev/null
                                # Add key and install packages
-                               apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0C54D189F4BA284D > /dev/null
-                               echo 'deb https://www.collaboraoffice.com/repos/CollaboraOnline/CODE-debian9 ./' > /etc/apt/sources.list.d/CollaboraOnline.list
+                               curl -fsSL https://collaboraoffice.com/repos/CollaboraOnline/CODE-debian12/Release.key | gpg --dearmor | tee /usr/share/keyrings/collaboraonline-keyring.gpg > /dev/null
+                               echo 'deb [signed-by=/usr/share/keyrings/collaboraonline-keyring.gpg] https://www.collaboraoffice.com/repos/CollaboraOnline/CODE-debian12 ./' > /etc/apt/sources.list.d/CollaboraOnline.list
                                apt-get update > /dev/null
                                apt-get install -y loolwsd code-brand > /dev/null
                                


### PR DESCRIPTION
## Summary
- replace deprecated `apt-key` usage with `curl | gpg --dearmor`
- point Collabora repo to current CODE Debian 12

## Testing
- `bash -n containers/25_configure_collabora.sh`
- `python3.12 --version`


------
https://chatgpt.com/codex/tasks/task_e_68af15b49b7c832998cedb64fbd69560