### PR TITLE
Enable TLSv1.3 and update ciphers

### DIFF
--- a/templates/rvprx/etc_nginx_RVPRX_common.conf
+++ b/templates/rvprx/etc_nginx_RVPRX_common.conf
@@ -9,9 +9,9 @@
 # https://mozilla.github.io/server-side-tls/ssl-config-generator/
 
 # drop SSLv3 (POODLE vulnerability)
-    ssl_protocols         TLSv1.2;
-# Recommanded ciphers
-    ssl_ciphers           'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
+    ssl_protocols         TLSv1.2 TLSv1.3;
+# Recommended ciphers
+    ssl_ciphers           'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305';
 # enables server-side protection from BEAST attacks
     ssl_prefer_server_ciphers on;
 # enable session resumption to improve https performance


### PR DESCRIPTION
## Summary
- support TLSv1.3 alongside TLSv1.2
- refresh nginx cipher list to Mozilla's modern profile

## Testing
- `npm test` (fails: Could not read package.json)
- `make test` (fails: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_68af15b58ab083298d4e8ba9b410ba20