### PR TITLE
Add zfs storage driver option

### DIFF
--- a/10_install_start.sh
+++ b/10_install_start.sh
@@ -186,8 +186,13 @@ EOF
 iptables-restore /etc/iptables/rules.v4
 
 ##### DEBIAN
-echo "$($_ORANGE_)Install: snapd, udev and btrfs$($_WHITE_)"
-DEBIAN_FRONTEND=noninteractive apt-get -y install snapd udev btrfs-progs > /dev/null
+if [ "$LXD_STORAGE_DRIVER" = "zfs" ]; then
+    echo "$($_ORANGE_)Install: snapd, udev and zfs$($_WHITE_)"
+    DEBIAN_FRONTEND=noninteractive apt-get -y install snapd udev zfsutils-linux > /dev/null
+else
+    echo "$($_ORANGE_)Install: snapd, udev and btrfs$($_WHITE_)"
+    DEBIAN_FRONTEND=noninteractive apt-get -y install snapd udev btrfs-progs > /dev/null
+fi
 DEBIAN_FRONTEND=noninteractive apt-get clean
 
 echo "$($_ORANGE_)Install: LXD with snap$($_WHITE_)"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Full personal cloud
 
 # This project are split in multiple subproject
 
+To select the storage backend for LXD, edit `config/03_OTHER_VARS` and set `LXD_STORAGE_DRIVER` to either `btrfs` (default) or `zfs`.
+
 Please see :
 + [Installation and lxd configuration](https://github.com/AlbanVidal/install_conf_lxd)
 + [Deploy of Nextcloud](https://github.com/AlbanVidal/deploy_nextcloud)

--- a/config/03_OTHER_VARS
+++ b/config/03_OTHER_VARS
@@ -36,6 +36,9 @@ CREATE_CERTIFICATES=true
 
 ################################################################################
 
+# Storage backend driver (btrfs, zfs, lvm)
+LXD_STORAGE_DRIVER="btrfs"
+
 # LXD default storage type (driver) and size
 #
 # For test time, the following command is used:
@@ -62,6 +65,17 @@ storage_pools:
   name: default
   driver: btrfs
 '
+
+## ZFS in loop device
+# Time: N/A
+LXD_STORAGE_LOOP_ZFS='
+storage_pools:
+- config:
+    size: 15GB
+  description: ""
+  name: default
+  driver: zfs
+'
 #
 ## LVM in bloc device
 # Time: 1m22.096s
@@ -85,12 +99,36 @@ storage_pools:
   driver: btrfs
 '
 
+## ZFS in bloc device
+# Time: N/A
+LXD_STORAGE_BLOC_ZFS='
+storage_pools:
+- config:
+    source: /dev/nbd1
+  description: ""
+  name: default
+  driver: zfs
+'
+
 # Set default storage:
 #
 # Bug with lvm !
 #LXD_DEFAULT_STORAGE="$LXD_STORAGE_LOOP_LVM"
 #
-LXD_DEFAULT_STORAGE="$LXD_STORAGE_LOOP_BTRFS"
+case "$LXD_STORAGE_DRIVER" in
+  zfs)
+    LXD_DEFAULT_STORAGE="$LXD_STORAGE_LOOP_ZFS"
+    ;;
+  btrfs)
+    LXD_DEFAULT_STORAGE="$LXD_STORAGE_LOOP_BTRFS"
+    ;;
+  lvm)
+    LXD_DEFAULT_STORAGE="$LXD_STORAGE_LOOP_LVM"
+    ;;
+  *)
+    LXD_DEFAULT_STORAGE="$LXD_STORAGE_LOOP_BTRFS"
+    ;;
+esac
 
 ################################################################################
 


### PR DESCRIPTION
## Summary
- allow choosing LXD storage backend via `LXD_STORAGE_DRIVER`
- install zfs packages when zfs driver selected
- document storage backend selection

## Testing
- `shellcheck 10_install_start.sh`
- `lxd init --storage-backend=btrfs --storage-pool=default --auto` (fails: command not found)
- `lxc storage list` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68af1eaedebc8329ab353641913a2e1e