### PR TITLE
Allow configurable Python package in install scripts

### DIFF
--- a/10_install_start.sh
+++ b/10_install_start.sh
@@ -103,8 +103,10 @@ source config/03_OTHER_VARS
 #############
 echo "$($_ORANGE_)Update and Upgrade system packages and default apt configuration$($_WHITE_)"
 
+# Allow overriding the Python package version; default to python3
+PYTHON_PACKAGE=${PYTHON_PACKAGE:-python3}
 
-PACKAGES="vim apt-utils bsd-mailx unattended-upgrades apt-listchanges bind9-host logrotate postfix python3.12 python-is-python3"
+PACKAGES="vim apt-utils bsd-mailx unattended-upgrades apt-listchanges bind9-host logrotate postfix ${PYTHON_PACKAGE} python-is-python3"
 
 
 

--- a/11_install_next.sh
+++ b/11_install_next.sh
@@ -209,8 +209,10 @@ sleep 5
 echo "$($_ORANGE_)Container TEMPLATE: Update, upgrade and install common packages$($_WHITE_)"
 
 
+# Allow overriding the Python package version; default to python3
+PYTHON_PACKAGE=${PYTHON_PACKAGE:-python3}
 
-PACKAGES="git vim apt-utils bsd-mailx postfix python3.12 python-is-python3"
+PACKAGES="git vim apt-utils bsd-mailx postfix ${PYTHON_PACKAGE} python-is-python3"
 
 
 lxc exec z-template -- bash -c "


### PR DESCRIPTION
## Summary
- expose a `PYTHON_PACKAGE` variable defaulting to `python3`
- use the variable in host and template installation scripts while keeping `python-is-python3`

## Testing
- `shellcheck 10_install_start.sh 11_install_next.sh`
- `bash -n 10_install_start.sh 11_install_next.sh`


------
https://chatgpt.com/codex/tasks/task_e_68af27ff3444832994452643f74c8017