### PR TITLE
Detect existing LXD storage driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Full personal cloud
 # This project are split in multiple subproject
 
 To select the storage backend for LXD, edit `config/03_OTHER_VARS` and set `LXD_STORAGE_DRIVER` to either `btrfs` (default) or `zfs`.
+The scripts automatically detect the driver of an existing `default` storage pool
+and reuse it. To switch to a different backend, remove any conflicting pools
+first (for example `lxc storage delete default`) before rerunning the
+initialization.
 
 Please see :
 + [Installation and lxd configuration](https://github.com/AlbanVidal/install_conf_lxd)

--- a/config/03_OTHER_VARS
+++ b/config/03_OTHER_VARS
@@ -37,7 +37,21 @@ CREATE_CERTIFICATES=true
 ################################################################################
 
 # Storage backend driver (btrfs, zfs, lvm)
+# The existing default pool driver will override this value if detected.
 LXD_STORAGE_DRIVER="btrfs"
+
+# Detect the current storage pool driver to avoid conflicts when re-running the
+# initialization scripts. If a default pool already exists, its driver is used
+# and LXD initialization is skipped. To change the storage backend, remove the
+# existing pool (e.g. "lxc storage delete default") before running the install
+# scripts again.
+if command -v lxc >/dev/null 2>&1; then
+  current_driver="$(lxc storage show default 2>/dev/null | awk '/^driver:/ {print $2}')"
+  if [ -n "$current_driver" ]; then
+    LXD_STORAGE_DRIVER="$current_driver"
+    LXD_INIT=false
+  fi
+fi
 
 # LXD default storage type (driver) and size
 #


### PR DESCRIPTION
## Summary
- Detect existing default storage pool driver and set `LXD_STORAGE_DRIVER` accordingly
- Document how to remove conflicting pools before rerunning initialization

## Testing
- `bash -n config/03_OTHER_VARS`
- `markdownlint README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af2804940883298e5e7d953d2b7586