### PR TITLE
Skip install when Nextcloud already present

### DIFF
--- a/containers/24_configure_cloud.sh
+++ b/containers/24_configure_cloud.sh
@@ -213,7 +213,11 @@ echo "$($_ORANGE_)Reload apache2$($_WHITE_)"
 lxc exec cloud -- bash -c "systemctl reload apache2"
 
 echo "$($_ORANGE_)Nextcloud installation$($_WHITE_)"
-lxc exec cloud -- bash -c "occ maintenance:install --database 'mysql' --database-host '$IP_mariadb_PRIV' --database-name 'nextcloud'  --database-user 'nextcloud' --database-pass '$MDP_nextcoud' --admin-user '$NEXTCLOUD_admin_user' --admin-pass '$NEXTCLOUD_admin_password' --data-dir='$NEXTCLOUD_DATA_DIR'"
+if lxc exec cloud -- bash -c '[ -f /var/www/nextcloud/config/config.php ] || occ status >/dev/null 2>&1'; then
+    echo "$($_GREEN_)Existing Nextcloud installation detected - reusing instance$($_WHITE_)"
+else
+    lxc exec cloud -- bash -c "occ maintenance:install --database 'mysql' --database-host '$IP_mariadb_PRIV' --database-name 'nextcloud'  --database-user 'nextcloud' --database-pass '$MDP_nextcoud' --admin-user '$NEXTCLOUD_admin_user' --admin-pass '$NEXTCLOUD_admin_password' --data-dir='$NEXTCLOUD_DATA_DIR'"
+fi
 
 echo "$($_ORANGE_)Tune MAX upload file size$($_WHITE_)"
 lxc exec cloud -- bash -c "sed -i \


### PR DESCRIPTION
## Summary
- skip `occ maintenance:install` if Nextcloud already configured
- log reuse of existing Nextcloud instance

## Testing
- `bash -n containers/24_configure_cloud.sh` *(fails: syntax error near line 120)*
- `shellcheck containers/24_configure_cloud.sh` *(fails: script has warnings/errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af2c44e84c8329b0192129a3f3c63a