### PR TITLE
Configure git user after package install

### DIFF
--- a/10_install_start.sh
+++ b/10_install_start.sh
@@ -113,6 +113,8 @@ PACKAGES="vim apt-utils bsd-mailx unattended-upgrades apt-listchanges bind9-host
 apt-get update > /dev/null
 DEBIAN_FRONTEND=noninteractive apt-get -y install $PACKAGES > /dev/null
 DEBIAN_FRONTEND=noninteractive apt-get -y upgrade > /dev/null
+git config --global user.name "$HOSTNAME"
+git config --global user.email "root@$HOSTNAME"
 
 # Basic Debian configuration
 mkdir -p /srv/git


### PR DESCRIPTION
## Summary
- Set git global user.name and user.email after package installation in 10_install_start.sh

## Testing
- `bash -n 10_install_start.sh`
- `cat /root/.gitconfig`


------
https://chatgpt.com/codex/tasks/task_e_68af549d4c8083298e92b506d6a986b1