### PR TITLE
feat: add logwatch daily reports

### DIFF
--- a/10_install_start.sh
+++ b/10_install_start.sh
@@ -107,7 +107,7 @@ echo "$($_ORANGE_)Update and Upgrade system packages and default apt configurati
 PYTHON_PACKAGE=${PYTHON_PACKAGE:-python3}
 
 
-PACKAGES="vim apt-utils bsd-mailx unattended-upgrades apt-listchanges bind9-host logrotate postfix git fail2ban ${PYTHON_PACKAGE} python-is-python3"
+PACKAGES="vim apt-utils bsd-mailx unattended-upgrades apt-listchanges bind9-host logrotate logwatch postfix git fail2ban ${PYTHON_PACKAGE} python-is-python3"
 
 
 
@@ -148,6 +148,13 @@ enabled = true
 EOF
 systemctl enable fail2ban >/dev/null 2>&1
 systemctl restart fail2ban >/dev/null 2>&1
+
+# Configure logwatch daily report
+cat << EOF > /etc/cron.daily/00logwatch
+#!/bin/bash
+logwatch --output mail --mailto "$TECH_ADMIN_EMAIL"
+EOF
+chmod +x /etc/cron.daily/00logwatch
 
 # Configure unattended upgrades notifications
 cat << EOF > /etc/apt/apt.conf.d/51unattended-upgrades-local


### PR DESCRIPTION
## Summary
- install logwatch alongside existing base packages
- configure a daily logwatch cron job that emails `$TECH_ADMIN_EMAIL`

## Testing
- `run-parts --test /etc/cron.daily`
- `logwatch --output mail --mailto root --detail low --range today`
- `ls -l /var/mail`


------
https://chatgpt.com/codex/tasks/task_e_68af54a4435483298750eab1a1a64c15