### PR TITLE
Add configurable ports and SMTP domain

### DIFF
--- a/10_install_start.sh
+++ b/10_install_start.sh
@@ -55,29 +55,30 @@ else
     echo ""
     echo "$($_ORANGE_)** TECHNICAL **$($_WHITE_)"
     echo ""
-    echo -n "$($_GREEN_)Internet network interface:$($_WHITE_) "
-    read INTERNET_ETH
-    echo -n "$($_GREEN_)FQDN:$($_WHITE_) "
-    read FQDN
-    echo -n "$($_GREEN_)Collabora FQDN:$($_WHITE_) "
-    read FQDN_collabora
-    echo -n "$($_GREEN_)Technical Administrator Email:$($_WHITE_) "
-    read TECH_ADMIN_EMAIL
+    read -p "$($_GREEN_)Internet network interface [$INTERNET_ETH]:$($_WHITE_) " input; INTERNET_ETH=${input:-$INTERNET_ETH}
+    read -p "$($_GREEN_)FQDN [$FQDN]:$($_WHITE_) " input; FQDN=${input:-$FQDN}
+    read -p "$($_GREEN_)Collabora FQDN [$FQDN_collabora]:$($_WHITE_) " input; FQDN_collabora=${input:-$FQDN_collabora}
+    read -p "$($_GREEN_)SMTP FQDN [$FQDN_smtp]:$($_WHITE_) " input; FQDN_smtp=${input:-$FQDN_smtp}
+    read -p "$($_GREEN_)HTTP port [$HTTP_PORT]:$($_WHITE_) " input; HTTP_PORT=${input:-$HTTP_PORT}
+    read -p "$($_GREEN_)HTTPS port [$HTTPS_PORT]:$($_WHITE_) " input; HTTPS_PORT=${input:-$HTTPS_PORT}
+    read -p "$($_GREEN_)Collabora port [$COLLABORA_PORT]:$($_WHITE_) " input; COLLABORA_PORT=${input:-$COLLABORA_PORT}
+    read -p "$($_GREEN_)Technical Administrator Email [$TECH_ADMIN_EMAIL]:$($_WHITE_) " input; TECH_ADMIN_EMAIL=${input:-$TECH_ADMIN_EMAIL}
 
     echo ""
     echo "$($_ORANGE_)** CLOUD **$($_WHITE_)"
     echo ""
-    echo -n "$($_GREEN_)Nextcloud Administrator User:$($_WHITE_) "
-    read NEXTCLOUD_admin_user
-    echo -n "$($_GREEN_)Nextcloud Administrator Email:$($_WHITE_) "
-    read NEXTCLOUD_admin_email
-    echo -n "$($_GREEN_)Nextcloud Administrator Password (hidden entry):$($_WHITE_) "
-    read -rs NEXTCLOUD_admin_password
+    read -p "$($_GREEN_)Nextcloud Administrator User [$NEXTCLOUD_admin_user]:$($_WHITE_) " input; NEXTCLOUD_admin_user=${input:-$NEXTCLOUD_admin_user}
+    read -p "$($_GREEN_)Nextcloud Administrator Email [$NEXTCLOUD_admin_email]:$($_WHITE_) " input; NEXTCLOUD_admin_email=${input:-$NEXTCLOUD_admin_email}
+    read -p "$($_GREEN_)Nextcloud Administrator Password (hidden entry):$($_WHITE_) " -rs input; NEXTCLOUD_admin_password=${input:-$NEXTCLOUD_admin_password}
 
     cat << EOF > config/00_VARS
 INTERNET_ETH="$INTERNET_ETH"
 FQDN="$FQDN"
 FQDN_collabora="$FQDN_collabora"
+FQDN_smtp="$FQDN_smtp"
+HTTP_PORT="$HTTP_PORT"
+HTTPS_PORT="$HTTPS_PORT"
+COLLABORA_PORT="$COLLABORA_PORT"
 TECH_ADMIN_EMAIL="$TECH_ADMIN_EMAIL"
 NEXTCLOUD_admin_user="$NEXTCLOUD_admin_user"
 NEXTCLOUD_admin_email="$NEXTCLOUD_admin_email"
@@ -218,10 +219,10 @@ cat << EOF > /etc/iptables/rules.v4
 # Internet Input (PREROUTING)
 -N zone_wan_PREROUTING
 -A PREROUTING -i $INTERNET_ETH -j zone_wan_PREROUTING -m comment --comment "Internet Input PREROUTING"
-# NAT 80 > RVPRX (nginx)
--A zone_wan_PREROUTING -p tcp -m tcp --dport 80 -j DNAT --to-destination $IP_rvprx:80 -m comment --comment "Routing port 80 > RVPRX - TCP"
-# NAT 443 > RVPRX (nginx)
--A zone_wan_PREROUTING -p tcp -m tcp --dport 443 -j DNAT --to-destination $IP_rvprx:443 -m comment --comment "Routing port 443 > RVPRX - TCP"
+# NAT ${HTTP_PORT} > RVPRX (nginx)
+-A zone_wan_PREROUTING -p tcp -m tcp --dport ${HTTP_PORT} -j DNAT --to-destination $IP_rvprx:${HTTP_PORT} -m comment --comment "Routing port ${HTTP_PORT} > RVPRX - TCP"
+# NAT ${HTTPS_PORT} > RVPRX (nginx)
+-A zone_wan_PREROUTING -p tcp -m tcp --dport ${HTTPS_PORT} -j DNAT --to-destination $IP_rvprx:${HTTPS_PORT} -m comment --comment "Routing port ${HTTPS_PORT} > RVPRX - TCP"
 COMMIT
 EOF
 iptables-restore /etc/iptables/rules.v4

--- a/config/00_VARS
+++ b/config/00_VARS
@@ -8,6 +8,12 @@ TECH_ADMIN_EMAIL="admin@example.com"
 # Fully qualified domain names
 FQDN="cloud.example.com"
 FQDN_collabora="office.example.com"
+FQDN_smtp="smtp.example.com"
+
+# Port configuration
+HTTP_PORT="80"
+HTTPS_PORT="443"
+COLLABORA_PORT="9980"
 
 # Nextcloud administrator credentials
 NEXTCLOUD_admin_user="admin"

--- a/containers/21_configure_smtp.sh
+++ b/containers/21_configure_smtp.sh
@@ -92,15 +92,15 @@ inet_interfaces = 127.0.0.1, _IP_SMTP_
 inet_protocols = ipv4
 EOF
 sed -i                                         \
-    -e "s#_myhostname_#$FQDN#"                 \
+    -e "s#_myhostname_#$FQDN_smtp#"            \
     -e "s#_PRIVATE_NETWORK_#$PRIVATE_NETWORK#" \
     -e "s#_IP_SMTP_#$IP_smtp_PRIV#"            \
     /tmp_lxd_smtp_etc_postfix_main.cf
 
 lxc file push /tmp_lxd_smtp_etc_postfix_main.cf smtp/etc/postfix/main.cf
-lxc exec smtp -- bash -c "echo $FQDN > /etc/mailname
+lxc exec smtp -- bash -c "echo $FQDN_smtp > /etc/mailname
                           systemctl restart postfix
-                          echo Test SMTP $FQDN|mail -s 'Test SMTP $FQDN' $NEXTCLOUD_admin_email
+                          echo Test SMTP $FQDN_smtp|mail -s 'Test SMTP $FQDN_smtp' $NEXTCLOUD_admin_email
                           "
 
 ################################################################################

--- a/containers/22_configure_rvprx.sh
+++ b/containers/22_configure_rvprx.sh
@@ -105,13 +105,13 @@ lxc file push $GIT_PATH/templates/rvprx/etc_nginx_RVPRX_common.conf rvprx/etc/ng
 # RVPRX vhosts
 cat << EOF > /tmp_lxd_rvprx_etc_nginx_rvprx-cloud
 server {
-    listen      80;
+    listen      ${HTTP_PORT};
     server_name $FQDN;
     return 301  https://$FQDN\$request_uri;
 }
 
 server {
-    listen      443 ssl http2;
+    listen      ${HTTPS_PORT} ssl http2;
     server_name $FQDN;
 
     # Let's Encrypt:
@@ -126,20 +126,20 @@ server {
     access_log /var/log/nginx/cloud_access.log;
     error_log  /var/log/nginx/cloud_error.log;
 
-    location / { proxy_pass http://$IP_cloud_PRIV/; }
+    location / { proxy_pass http://$IP_cloud_PRIV:${HTTP_PORT}/; }
 }
 EOF
 lxc file push /tmp_lxd_rvprx_etc_nginx_rvprx-cloud rvprx/etc/nginx/sites-available/rvprx-cloud
 
 cat << EOF > /tmp_lxd_rvprx_etc_nginx_rvprx-collabora
 server {
-    listen      80;
+    listen      ${HTTP_PORT};
     server_name $FQDN_collabora;
     return 301  https://$FQDN_collabora\$request_uri;
 }
 
 server {
-    listen      443 ssl http2;
+    listen      ${HTTPS_PORT} ssl http2;
     server_name $FQDN_collabora;
 
     # Let's Encrypt:
@@ -156,19 +156,19 @@ server {
 
     # static files
     location ^~ /loleaflet {
-        proxy_pass https://$IP_collabora_PRIV:9980;
+        proxy_pass https://$IP_collabora_PRIV:${COLLABORA_PORT};
         proxy_set_header Host \$http_host;
     }
 
     # WOPI discovery URL
     location ^~ /hosting/discovery {
-        proxy_pass https://$IP_collabora_PRIV:9980;
+        proxy_pass https://$IP_collabora_PRIV:${COLLABORA_PORT};
         proxy_set_header Host \$http_host;
     }
 
    # main websocket
    location ~ ^/lool/(.*)/ws$ {
-       proxy_pass https://$IP_collabora_PRIV:9980;
+       proxy_pass https://$IP_collabora_PRIV:${COLLABORA_PORT};
        proxy_set_header Upgrade \$http_upgrade;
        proxy_set_header Connection "Upgrade";
        proxy_set_header Host \$http_host;
@@ -177,13 +177,13 @@ server {
    
    # download, presentation and image upload
    location ~ ^/lool {
-       proxy_pass https://$IP_collabora_PRIV:9980;
+       proxy_pass https://$IP_collabora_PRIV:${COLLABORA_PORT};
        proxy_set_header Host \$http_host;
    }
    
    # Admin Console websocket
    location ^~ /lool/adminws {
-       proxy_pass https://$IP_collabora_PRIV:9980;
+       proxy_pass https://$IP_collabora_PRIV:${COLLABORA_PORT};
        proxy_set_header Upgrade \$http_upgrade;
        proxy_set_header Connection "Upgrade";
        proxy_set_header Host \$http_host;


### PR DESCRIPTION
## Summary
- prompt for FQDN_smtp and configurable HTTP/HTTPS/Collabora ports
- persist new settings in config and apply them to NAT rules and rvprx
- use dedicated SMTP FQDN in smtp container setup

## Testing
- `bash -n 10_install_start.sh containers/22_configure_rvprx.sh containers/21_configure_smtp.sh`


------
https://chatgpt.com/codex/tasks/task_e_68af5cf9358c8329a7bdd3203c28f5b6