### PR TITLE
Use local basic Debian configuration script

### DIFF
--- a/11_install_next.sh
+++ b/11_install_next.sh
@@ -274,19 +274,26 @@ PYTHON_PACKAGE=${PYTHON_PACKAGE:-python3}
 PACKAGES="git vim apt-utils bsd-mailx postfix ${PYTHON_PACKAGE} python-is-python3"
 
 
+# Initial package installation in the template container
 lxc exec z-template -- bash -c "
     apt-get update > /dev/null
     DEBIAN_FRONTEND=noninteractive apt-get -y install $PACKAGES > /dev/null
     DEBIAN_FRONTEND=noninteractive apt-get -y upgrade > /dev/null
-    # Basic Debian configuration
-    mkdir -p /srv/git
-    git clone https://github.com/AlbanVidal/basic_config_debian.git /srv/git/basic_config_debian
+    mkdir -p /srv/git/basic_config_debian
+"
+
+# Use local basic_config_debian instead of cloning from the Internet
+lxc file push templates/basic_config_debian/auto_config.sh \
+    z-template/srv/git/basic_config_debian/auto_config.sh
+
+lxc exec z-template -- bash -c "
     # Setup config file for auto configuration
-    >                                                /srv/git/basic_config_debian/conf
+    > /srv/git/basic_config_debian/conf
     echo 'UNATTENDED_EMAIL=\"$TECH_ADMIN_EMAIL\"' >> /srv/git/basic_config_debian/conf
     echo 'GIT_USERNAME=\"$HOSTNAME\"'             >> /srv/git/basic_config_debian/conf
     echo 'GIT_EMAIL=\"root@$HOSTNAME\"'           >> /srv/git/basic_config_debian/conf
     echo 'SSH_EMAIL_ALERT=\"$TECH_ADMIN_EMAIL\"'  >> /srv/git/basic_config_debian/conf
+    chmod +x /srv/git/basic_config_debian/auto_config.sh
     # Launch auto configuration script
     /srv/git/basic_config_debian/auto_config.sh
 "

--- a/templates/basic_config_debian/auto_config.sh
+++ b/templates/basic_config_debian/auto_config.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+# Local version of basic Debian configuration script
+# This script reads configuration variables from
+# /srv/git/basic_config_debian/conf if present and applies
+# a minimal set of system defaults.
+
+CONF_DIR="/srv/git/basic_config_debian"
+CONF_FILE="$CONF_DIR/conf"
+
+if [ -f "$CONF_FILE" ]; then
+    # shellcheck source=/dev/null
+    source "$CONF_FILE"
+fi
+
+# Configure git defaults when provided
+if [ -n "$GIT_USERNAME" ]; then
+    git config --global user.name "$GIT_USERNAME"
+fi
+
+if [ -n "$GIT_EMAIL" ]; then
+    git config --global user.email "$GIT_EMAIL"
+fi
+
+# Configure unattended-upgrades email notifications
+if [ -n "$UNATTENDED_EMAIL" ]; then
+    sed -E -i "s|^(//\s*)?Unattended-Upgrade::Mail.*|Unattended-Upgrade::Mail \"$UNATTENDED_EMAIL\";|" /etc/apt/apt.conf.d/50unattended-upgrades
+    cat <<EOF > /etc/apt/apt.conf.d/51unattended-upgrades-local
+Unattended-Upgrade::Mail "$UNATTENDED_EMAIL";
+EOF
+    echo "root: $UNATTENDED_EMAIL" >> /etc/aliases
+    newaliases >/dev/null 2>&1 || true
+fi
+
+exit 0
+


### PR DESCRIPTION
## Summary
- Avoid GitHub authentication prompts by replacing remote `basic_config_debian` clone with local script
- Add minimal `auto_config.sh` to configure git defaults and unattended-upgrades inside containers

## Testing
- `bash -n install.sh 10_install_start.sh 11_install_next.sh templates/basic_config_debian/auto_config.sh`
- `shellcheck install.sh 11_install_next.sh templates/basic_config_debian/auto_config.sh`

------
https://chatgpt.com/codex/tasks/task_e_68af756510708329b04efdfcb80cc53d