### PR TITLE
Add dockbin docking result tiles layout

### DIFF
--- a/dockbin/templates/docking_result_tiles.html
+++ b/dockbin/templates/docking_result_tiles.html
@@ -1,0 +1,14 @@
+{% extends "layout.html" %}
+
+{% block title %}Dockbin results{% endblock %}
+
+{% block content %}
+<div class="tiles">
+  {% for tile in tiles %}
+  <a class="tile" href="{{ url_for('dockbin.show', id=tile.id) }}">
+    <h2>{{ tile.title }}</h2>
+    <p>{{ tile.blurb }}</p>
+  </a>
+  {% endfor %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add `dockbin/templates/docking_result_tiles.html` with tile-style results template renamed from notebin to dockbin

## Testing
- `npm test` (fails: could not read package.json)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af7d5d4c50832989f8bde68cfa33dd