### PR TITLE
chore: add dockbin docking compare template

### DIFF
--- a/dockbin/templates/docking_compare.html
+++ b/dockbin/templates/docking_compare.html
@@ -1,0 +1,11 @@
+<!-- TODO: Replace with actual template content from notebin, updated for dockbin -->
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Dockbin Comparison</title>
+</head>
+<body>
+    <h1>Dockbin Comparison</h1>
+    <p>This is a placeholder for the docking comparison template.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add placeholder docking comparison template for dockbin

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af7d5bc0a88329b6a4e5afd1f76b50