### PR TITLE
feat: allow domain overrides via installer flags

### DIFF
--- a/10_install_start.sh
+++ b/10_install_start.sh
@@ -47,6 +47,20 @@ _ORANGE_="tput setaf 3"
 # If vars file exist, source
 if [ -f config/00_VARS ]; then
     source config/00_VARS
+
+    # Override domains from environment variables when provided
+    if [ -n "$FQDN_OVERRIDE" ]; then
+        FQDN="$FQDN_OVERRIDE"
+        sed -i "s/^FQDN=.*/FQDN=\"$FQDN\"/" config/00_VARS
+    fi
+    if [ -n "$FQDN_COLLABORA_OVERRIDE" ]; then
+        FQDN_collabora="$FQDN_COLLABORA_OVERRIDE"
+        sed -i "s/^FQDN_collabora=.*/FQDN_collabora=\"$FQDN_collabora\"/" config/00_VARS
+    fi
+    if [ -n "$FQDN_SMTP_OVERRIDE" ]; then
+        FQDN_smtp="$FQDN_SMTP_OVERRIDE"
+        sed -i "s/^FQDN_smtp=.*/FQDN_smtp=\"$FQDN_smtp\"/" config/00_VARS
+    fi
 else
     echo ""
     echo "$($_RED_)File « config/00_VARS » don't exist$($_WHITE_)"
@@ -55,6 +69,9 @@ else
     echo ""
     echo "$($_ORANGE_)** TECHNICAL **$($_WHITE_)"
     echo ""
+    FQDN=${FQDN_OVERRIDE:-$FQDN}
+    FQDN_collabora=${FQDN_COLLABORA_OVERRIDE:-$FQDN_collabora}
+    FQDN_smtp=${FQDN_SMTP_OVERRIDE:-$FQDN_smtp}
     read -p "$($_GREEN_)Internet network interface [$INTERNET_ETH]:$($_WHITE_) " input; INTERNET_ETH=${input:-$INTERNET_ETH}
     read -p "$($_GREEN_)FQDN [$FQDN]:$($_WHITE_) " input; FQDN=${input:-$FQDN}
     read -p "$($_GREEN_)Collabora FQDN [$FQDN_collabora]:$($_WHITE_) " input; FQDN_collabora=${input:-$FQDN_collabora}

--- a/README.md
+++ b/README.md
@@ -32,3 +32,12 @@ Install only specific components by combining flags:
 
 Run `./install.sh --help` to see all available options.
 
+Specify custom domain names when running the installer:
+
+```
+./install.sh --nextcloud \
+    --fqdn cloud.example.com \
+    --collabora-fqdn office.example.com \
+    --smtp-fqdn smtp.example.com
+```
+

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,9 @@ Options:
   --rvprx       Install reverse proxy container
   --mariadb     Install MariaDB container
   --collabora   Install Collabora container
+  --fqdn DOMAIN             Set Nextcloud FQDN
+  --collabora-fqdn DOMAIN   Set Collabora FQDN
+  --smtp-fqdn DOMAIN        Set SMTP FQDN
   -h, --help    Show this help
 USAGE
 }
@@ -44,6 +47,18 @@ while [[ $# -gt 0 ]]; do
             components+=(collabora)
             shift
             ;;
+        --fqdn)
+            FQDN_OVERRIDE="$2"
+            shift 2
+            ;;
+        --collabora-fqdn)
+            FQDN_COLLABORA_OVERRIDE="$2"
+            shift 2
+            ;;
+        --smtp-fqdn)
+            FQDN_SMTP_OVERRIDE="$2"
+            shift 2
+            ;;
         -h|--help)
             show_help
             exit 0
@@ -69,6 +84,7 @@ fi
 mapfile -t components < <(printf '%s\n' "${components[@]}" | sort -u)
 
 # Run base installation script once
+export FQDN_OVERRIDE FQDN_COLLABORA_OVERRIDE FQDN_SMTP_OVERRIDE
 ./10_install_start.sh
 
 # Pass component list to next script


### PR DESCRIPTION
## Summary
- allow passing Nextcloud, Collabora, and SMTP domains to `install.sh`
- update startup script to apply and persist domain overrides
- document new domain flags in README

## Testing
- `bash -n install.sh 10_install_start.sh`
- `./install.sh --help`


------
https://chatgpt.com/codex/tasks/task_e_68af80d502dc8329b13dd10f30082be5