### PR TITLE
feat: allow domain overrides via installer flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,18 @@ Install only specific components by combining flags:
 
 Run `./install.sh --help` to see all available options.
 
+Specify custom domain names when running the installer:
+
+```
+./install.sh --nextcloud \
+    --fqdn cloud.example.com \
+    --collabora-fqdn office.example.com \
+    --smtp-fqdn smtp.example.com
+```
+
+Skip DNS validation when records are not yet configured:
+
+```
+./install.sh --nextcloud --skip-dns-check
+```
+

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,10 @@ Options:
   --rvprx       Install reverse proxy container
   --mariadb     Install MariaDB container
   --collabora   Install Collabora container
+  --fqdn DOMAIN             Set Nextcloud FQDN
+  --collabora-fqdn DOMAIN   Set Collabora FQDN
+  --smtp-fqdn DOMAIN        Set SMTP FQDN
+  --skip-dns-check         Skip FQDN DNS validation
   -h, --help    Show this help
 USAGE
 }
@@ -44,6 +48,22 @@ while [[ $# -gt 0 ]]; do
             components+=(collabora)
             shift
             ;;
+        --fqdn)
+            FQDN_OVERRIDE="$2"
+            shift 2
+            ;;
+        --collabora-fqdn)
+            FQDN_COLLABORA_OVERRIDE="$2"
+            shift 2
+            ;;
+        --smtp-fqdn)
+            FQDN_SMTP_OVERRIDE="$2"
+            shift 2
+            ;;
+        --skip-dns-check)
+            SKIP_DNS_CHECK=1
+            shift
+            ;;
         -h|--help)
             show_help
             exit 0
@@ -69,6 +89,7 @@ fi
 mapfile -t components < <(printf '%s\n' "${components[@]}" | sort -u)
 
 # Run base installation script once
+export FQDN_OVERRIDE FQDN_COLLABORA_OVERRIDE FQDN_SMTP_OVERRIDE SKIP_DNS_CHECK
 ./10_install_start.sh
 
 # Pass component list to next script


### PR DESCRIPTION
## Summary
- allow passing Nextcloud, Collabora, and SMTP domains to `install.sh`
- update startup script to apply and persist domain overrides
- add `--skip-dns-check` flag to bypass FQDN validation when DNS records aren't ready
- document new installer flags in README

## Testing
- `bash -n install.sh 10_install_start.sh`
- `./install.sh --help`


------
https://chatgpt.com/codex/tasks/task_e_68af80d502dc8329b13dd10f30082be5