### PR TITLE
Fix NAT setup and auto-create LXD resource profiles

### DIFF
--- a/10_install_start.sh
+++ b/10_install_start.sh
@@ -239,13 +239,13 @@ DEBIAN_FRONTEND=noninteractive apt-get -y install iptables-persistent > /dev/nul
 echo "$($_ORANGE_)Enable Masquerade and NAT rules$($_WHITE_)"
 cat << EOF > /etc/iptables/rules.v4
 ################################################################################
-##########                          TABLE NAT                         ########## 
+##########                          TABLE NAT                         ##########
 ################################################################################
 *nat
 ####
 :PREROUTING ACCEPT [0:0]
-# Internet Input (PREROUTING)
--N zone_wan_PREROUTING
+# Custom chain for WAN prerouting
+:zone_wan_PREROUTING - [0:0]
 -A PREROUTING -i $INTERNET_ETH -j zone_wan_PREROUTING -m comment --comment "Internet Input PREROUTING"
 # NAT ${HTTP_PORT} > RVPRX (nginx)
 -A zone_wan_PREROUTING -p tcp -m tcp --dport ${HTTP_PORT} -j DNAT --to-destination $IP_rvprx:${HTTP_PORT} -m comment --comment "Routing port ${HTTP_PORT} > RVPRX - TCP"


### PR DESCRIPTION
## Summary
- fix iptables rules file so NAT chain loads without errors
- auto-create missing CPU and RAM LXD profiles during container setup

## Testing
- `bash -n 10_install_start.sh 11_install_next.sh`
- `./install.sh --help`

------
https://chatgpt.com/codex/tasks/task_e_68b2231b8100832994645a182a948999