### PR TITLE
Skip LXD reinitialization and reuse existing containers

### DIFF
--- a/10_install_start.sh
+++ b/10_install_start.sh
@@ -266,7 +266,11 @@ fi
 DEBIAN_FRONTEND=noninteractive apt-get clean
 
 echo "$($_ORANGE_)Install: LXD with snap$($_WHITE_)"
-snap install lxd --channel="$LXD_SNAP_CHANNEL"
+if snap list | grep -q '^lxd\s'; then
+    echo "$($_ORANGE_)LXD snap already installed, skipping$($_WHITE_)"
+else
+    snap install lxd --channel="$LXD_SNAP_CHANNEL"
+fi
 
 ##### UBUNTU
 ## Install LXD package


### PR DESCRIPTION
## Summary
- avoid reinstalling LXD snap when already present
- detect existing LXD config and containers before running `lxd init` or creating templates

## Testing
- `shellcheck 10_install_start.sh 11_install_next.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b229f625888329b17123d9b07dea24