### PR TITLE
Allow overriding service ports via install flags

### DIFF
--- a/10_install_start.sh
+++ b/10_install_start.sh
@@ -61,6 +61,18 @@ if [ -f config/00_VARS ]; then
         FQDN_smtp="$FQDN_SMTP_OVERRIDE"
         sed -i "s/^FQDN_smtp=.*/FQDN_smtp=\"$FQDN_smtp\"/" config/00_VARS
     fi
+    if [ -n "$HTTP_PORT_OVERRIDE" ]; then
+        HTTP_PORT="$HTTP_PORT_OVERRIDE"
+        sed -i "s/^HTTP_PORT=.*/HTTP_PORT=\"$HTTP_PORT\"/" config/00_VARS
+    fi
+    if [ -n "$HTTPS_PORT_OVERRIDE" ]; then
+        HTTPS_PORT="$HTTPS_PORT_OVERRIDE"
+        sed -i "s/^HTTPS_PORT=.*/HTTPS_PORT=\"$HTTPS_PORT\"/" config/00_VARS
+    fi
+    if [ -n "$COLLABORA_PORT_OVERRIDE" ]; then
+        COLLABORA_PORT="$COLLABORA_PORT_OVERRIDE"
+        sed -i "s/^COLLABORA_PORT=.*/COLLABORA_PORT=\"$COLLABORA_PORT\"/" config/00_VARS
+    fi
 else
     echo ""
     echo "$($_RED_)File « config/00_VARS » don't exist$($_WHITE_)"
@@ -72,6 +84,9 @@ else
     FQDN=${FQDN_OVERRIDE:-$FQDN}
     FQDN_collabora=${FQDN_COLLABORA_OVERRIDE:-$FQDN_collabora}
     FQDN_smtp=${FQDN_SMTP_OVERRIDE:-$FQDN_smtp}
+    HTTP_PORT=${HTTP_PORT_OVERRIDE:-$HTTP_PORT}
+    HTTPS_PORT=${HTTPS_PORT_OVERRIDE:-$HTTPS_PORT}
+    COLLABORA_PORT=${COLLABORA_PORT_OVERRIDE:-$COLLABORA_PORT}
     read -p "$($_GREEN_)Internet network interface [$INTERNET_ETH]:$($_WHITE_) " input; INTERNET_ETH=${input:-$INTERNET_ETH}
     read -p "$($_GREEN_)FQDN [$FQDN]:$($_WHITE_) " input; FQDN=${input:-$FQDN}
     read -p "$($_GREEN_)Collabora FQDN [$FQDN_collabora]:$($_WHITE_) " input; FQDN_collabora=${input:-$FQDN_collabora}

--- a/README.md
+++ b/README.md
@@ -43,3 +43,15 @@ Specify custom domain names when running the installer:
 
 Skip DNS validation when records are not yet configured:
 
+```
+./install.sh --skip-dns-check
+```
+
+Use custom ports for the reverse proxy and Collabora:
+
+```
+./install.sh --all \
+    --http-port 8080 \
+    --https-port 8443 \
+    --collabora-port 9980
+```

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,9 @@ Options:
   --fqdn DOMAIN             Set Nextcloud FQDN
   --collabora-fqdn DOMAIN   Set Collabora FQDN
   --smtp-fqdn DOMAIN        Set SMTP FQDN
+  --http-port PORT          Set HTTP port
+  --https-port PORT         Set HTTPS port
+  --collabora-port PORT     Set Collabora port
   --skip-dns-check         Skip FQDN DNS validation
   -h, --help                Show this help
 USAGE
@@ -60,6 +63,18 @@ while [[ $# -gt 0 ]]; do
             FQDN_SMTP_OVERRIDE="$2"
             shift 2
             ;;
+        --http-port)
+            HTTP_PORT_OVERRIDE="$2"
+            shift 2
+            ;;
+        --https-port)
+            HTTPS_PORT_OVERRIDE="$2"
+            shift 2
+            ;;
+        --collabora-port)
+            COLLABORA_PORT_OVERRIDE="$2"
+            shift 2
+            ;;
         --skip-dns-check)
             SKIP_DNS_CHECK=1
             shift
@@ -89,7 +104,9 @@ fi
 mapfile -t components < <(printf '%s\n' "${components[@]}" | sort -u)
 
 # Run base installation script once
-export FQDN_OVERRIDE FQDN_COLLABORA_OVERRIDE FQDN_SMTP_OVERRIDE SKIP_DNS_CHECK
+export FQDN_OVERRIDE FQDN_COLLABORA_OVERRIDE FQDN_SMTP_OVERRIDE \
+       HTTP_PORT_OVERRIDE HTTPS_PORT_OVERRIDE COLLABORA_PORT_OVERRIDE \
+       SKIP_DNS_CHECK
 ./10_install_start.sh
 
 # Pass component list to next script


### PR DESCRIPTION
## Summary
- add --http-port, --https-port and --collabora-port options to install.sh
- propagate port overrides to 10_install_start.sh and update config
- document usage of new port flags in README

## Testing
- `bash -n install.sh`
- `bash -n 10_install_start.sh`
- `./install.sh --help`


------
https://chatgpt.com/codex/tasks/task_e_68b22acb1a3c83299bed8f367ae468a7