### PR TITLE
feat: configurable port forwarding

### DIFF
--- a/11_install_next.sh
+++ b/11_install_next.sh
@@ -434,4 +434,18 @@ if has_component collabora; then
     ./containers/25_configure_collabora.sh
 fi
 
+if [ "${USE_LXD_PROXY}" = "1" ]; then
+    IFS=' ' read -r -a _extra_forwards <<< "${PORT_FORWARDS:-}"
+    _extra_forwards+=("${HTTP_PORT}:rvprx:${HTTP_PORT}" "${HTTPS_PORT}:rvprx:${HTTPS_PORT}")
+    for _map in "${_extra_forwards[@]}"; do
+        IFS=':' read -r _host_port _ct _ct_port <<< "$_map"
+        _ct_port=${_ct_port:-$_host_port}
+        _var="IP_${_ct}"
+        _ct_ip=$(eval echo "\${$_var}")
+        if lxc info "${_ct}" >/dev/null 2>&1; then
+            lxc config device add "${_ct}" "proxy${_host_port}" proxy listen="tcp:0.0.0.0:${_host_port}" connect="tcp:${_ct_ip}:${_ct_port}" >/dev/null 2>&1
+        fi
+    done
+fi
+
 ################################################################################

--- a/README.md
+++ b/README.md
@@ -43,3 +43,17 @@ Specify custom domain names when running the installer:
 
 Skip DNS validation when records are not yet configured:
 
+Forward additional host ports with the `--port-forward` flag. The format is
+`HOST_PORT:CONTAINER[:CONTAINER_PORT]`. For example, to expose SMTP on port 25
+and a custom service on port 8080:
+
+```
+./install.sh --all \
+    --port-forward 25:smtp \
+    --port-forward 8080:rvprx:8081
+```
+
+Ports 80 and 443 are automatically mapped to the `rvprx` container. Use
+`--use-lxd-proxy` if you prefer LXD proxy devices instead of iptables rules for
+the port forwarding.
+

--- a/install.sh
+++ b/install.sh
@@ -16,11 +16,14 @@ Options:
   --collabora-fqdn DOMAIN   Set Collabora FQDN
   --smtp-fqdn DOMAIN        Set SMTP FQDN
   --skip-dns-check         Skip FQDN DNS validation
+  --port-forward SPEC       Add extra port forward (HOST_PORT:CONTAINER[:CONTAINER_PORT])
+  --use-lxd-proxy          Use LXD proxy devices instead of iptables
   -h, --help                Show this help
 USAGE
 }
 
 components=()
+port_forwards=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -64,6 +67,14 @@ while [[ $# -gt 0 ]]; do
             SKIP_DNS_CHECK=1
             shift
             ;;
+        --port-forward)
+            port_forwards+=("$2")
+            shift 2
+            ;;
+        --use-lxd-proxy)
+            USE_LXD_PROXY=1
+            shift
+            ;;
         -h|--help)
             show_help
             exit 0
@@ -90,6 +101,7 @@ mapfile -t components < <(printf '%s\n' "${components[@]}" | sort -u)
 
 # Run base installation script once
 export FQDN_OVERRIDE FQDN_COLLABORA_OVERRIDE FQDN_SMTP_OVERRIDE SKIP_DNS_CHECK
+export PORT_FORWARDS="${port_forwards[*]}" USE_LXD_PROXY
 ./10_install_start.sh
 
 # Pass component list to next script


### PR DESCRIPTION
## Summary
- allow specifying extra host-to-container port forwards
- optionally use LXD proxy devices instead of iptables rules
- document port forwarding and proxy usage

## Testing
- `shellcheck 10_install_start.sh install.sh 11_install_next.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b22acce9b48329a51f08e64546b3cb