### PR TITLE
Improve staged install flow and documentation

### DIFF
--- a/10_install_start.sh
+++ b/10_install_start.sh
@@ -320,8 +320,12 @@ fi
 
 echo "$($_GREEN_)LXD is installed$($_WHITE_)"
 echo ""
-echo "$($_RED_)Please logout/login in bash to prevent snap bug and start script :$($_WHITE_)"
-echo "$($_GREEN_)11_install_next.sh$($_WHITE_)"
+
+if ! id -nG "$USER" | grep -qw lxd; then
+    echo "$($_RED_)Please logout/login in bash to prevent snap bug and start script :$($_WHITE_)"
+    echo "$($_GREEN_)11_install_next.sh$($_WHITE_)"
+    exit 0
+fi
 
 # Test if /run/reboot-required file exist, and print warning
 if [ -f /run/reboot-required ] ; then

--- a/README.md
+++ b/README.md
@@ -17,10 +17,17 @@ Please see :
 
 ## Installation
 
-Use the `install.sh` helper to run the various setup steps. Run all components:
+The installation now runs in two stages. Invoke `install.sh` with your desired
+components. The first run prepares the host and installs LXD, then asks you to
+log out so the `lxd` group membership can take effect. After logging back in,
+re-run the same command to deploy the selected containers.
+
+Run all components:
 
 ```
-./install.sh --all
+./install.sh --all   # first run
+# log out and log back in
+./install.sh --all   # second run to finish
 ```
 
 Install only specific components by combining flags:

--- a/install.sh
+++ b/install.sh
@@ -121,5 +121,10 @@ export FQDN_OVERRIDE FQDN_COLLABORA_OVERRIDE FQDN_SMTP_OVERRIDE \
 
 ./10_install_start.sh
 
+# Only continue if the first stage didn't request a logout (user already in lxd group)
+if ! id -nG "$USER" | grep -qw lxd; then
+    exit 0
+fi
+
 # Pass component list to next script
 ./11_install_next.sh "${components[@]}"


### PR DESCRIPTION
## Summary
- exit early from `10_install_start.sh` when logout is required
- run `11_install_next.sh` only after first stage completes with `lxd` group
- document the two-step installation workflow

## Testing
- `bash -n 10_install_start.sh install.sh`
- `./install.sh --help`


------
https://chatgpt.com/codex/tasks/task_e_68b45494a6048329bfe2c03c355724ea