### PR TITLE
Skip lxd group check for root users

### DIFF
--- a/10_install_start.sh
+++ b/10_install_start.sh
@@ -321,7 +321,8 @@ fi
 echo "$($_GREEN_)LXD is installed$($_WHITE_)"
 echo ""
 
-if ! id -nG "$USER" | grep -qw lxd; then
+# Non-root users must log out if not yet in the lxd group
+if [ "$EUID" -ne 0 ] && ! id -nG "$USER" | grep -qw lxd; then
     echo "$($_RED_)Please logout/login in bash to prevent snap bug and start script :$($_WHITE_)"
     echo "$($_GREEN_)11_install_next.sh$($_WHITE_)"
     exit 0

--- a/install.sh
+++ b/install.sh
@@ -122,7 +122,8 @@ export FQDN_OVERRIDE FQDN_COLLABORA_OVERRIDE FQDN_SMTP_OVERRIDE \
 ./10_install_start.sh
 
 # Only continue if the first stage didn't request a logout (user already in lxd group)
-if ! id -nG "$USER" | grep -qw lxd; then
+# Skip this check when running as root, which already has LXD access
+if [ "$EUID" -ne 0 ] && ! id -nG "$USER" | grep -qw lxd; then
     exit 0
 fi
 


### PR DESCRIPTION
## Summary
- allow install script to run second stage when executed as root
- only prompt logout for non-root users missing lxd group

## Testing
- `bash -n install.sh`
- `bash -n 10_install_start.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b463c1c2c88329970772fd04238664